### PR TITLE
Fix changeset monorepo setup conflict

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
-packages:
-  - next-app-mock
+
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
Remove 'next-app-mock' from the workspace packages list.