### PR TITLE
chore(deps): upgrade to pnpm 11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [22,24,26]
         nextjs-version: ['14.0.0', '14.2.30', '15.0.0', '15.3.4']
         os: [ubuntu-latest]
         exclude:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [20,22]
+        node-version: [22]
         nextjs-version: ['14.0.0', '14.2.30', '15.0.0', '15.3.4']
         os: [ubuntu-latest]
         exclude:

--- a/next-app-mock/package.json
+++ b/next-app-mock/package.json
@@ -21,5 +21,5 @@
     "eslint-config-next": "16.2.6",
     "typescript": "^5.8.3"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.21.0"
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "next": "^14.0 || ^15.0 || ^16.0.0",
     "react": "^18.0 || ^19.0"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.21.0",
   "dependencies": {
     "tsup": "^8.5.0",
     "use-debounce": "^10.0.6"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 
 
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
-  - unrs-resolver
+allowBuilds:
+  esbuild: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary

- upgrade the root and test application package managers to pnpm 11
- migrate dependency build approvals from the removed `onlyBuiltDependencies` setting to `allowBuilds`

Migration guidance: https://pnpm.io/settings/build#allowbuilds

## Validation

GitHub Actions will validate install, lint, types, builds, and Playwright tests.