### PR TITLE
chore: use shared Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "local>RevoTale/.github:renovate-config",
     "group:allNonMajor"
   ]
 }


### PR DESCRIPTION
Use the shared RevoTale Renovate preset (`local>RevoTale/.github:renovate-config`), which currently extends `config:best-practices`. Existing `group:allNonMajor` behavior is preserved.